### PR TITLE
VN-953: Extract patch to fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/diff": "^4.0.2",
     "@types/jest": "^26.0.19",
+    "@types/lodash": "^4.14.172",
     "@types/react-native": "0.63.2",
     "jest": "26.6.3",
     "ts-jest": "^26.4.4",
@@ -40,6 +41,7 @@
   },
   "dependencies": {
     "diff": "5.0.0",
+    "lodash": "^4.17.21",
     "string.prototype.matchall": "4.0.3"
   },
   "jest": {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,6 @@
 import { diffChars } from 'diff';
 import { StyleProp, TextStyle } from 'react-native';
+import { capitalize } from 'lodash';
 // @ts-ignore the lib do not have TS declarations yet
 import matchAll from 'string.prototype.matchall';
 import {
@@ -25,7 +26,15 @@ const mentionRegEx = /((.)\[([^[]*)]\(([^(^)]*)\))/gi;
 
 const defaultMentionTextStyle: StyleProp<TextStyle> = {fontWeight: 'bold', color: 'blue'};
 
-const defaultPlainStringGenerator = ({trigger}: MentionPartType, {name}: MentionData) => `${trigger}${name}`;
+const defaultPlainStringGenerator = ({ trigger }: { trigger?: string | undefined }, { name }: { name?: string }) : string => {
+  if (!trigger || !name) {
+    return '';
+  }
+  const splitName = name?.split(' ') || [];
+  const firstName = capitalize(splitName[0]);
+  const lastName = splitName[1] ? ` ${capitalize(splitName[1][0])}.` : '';
+  return `${firstName}${lastName}`;
+};
 
 const isMentionPartType = (partType: PartType): partType is MentionPartType => {
   return (partType as MentionPartType).trigger != null;

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -47,10 +47,10 @@ test('generates regex result part', () => {
   const mentionData = {original: mentionValue, trigger: mentionPartType.trigger, ...users[1]};
   const mentionPart = generateMentionPart(mentionPartType, mentionData);
   expect(mentionPart).toEqual<Part>({
-    text: '@Mary',
+    text: 'Mary',
     partType: mentionPartType,
     data: mentionData,
-    position: {start: 0, end: '@Mary'.length},
+    position: {start: 0, end: 'Mary'.length},
   });
 });
 
@@ -92,14 +92,14 @@ test('generates correct parts', () => {
   const mentionValue = '@[David](1:@)';
   const expectedMentionPart = {
     partType: mentionPartType,
-    text: '@David',
+    text: 'David',
     data: {
       id: '1:@',
       name: 'David',
       trigger: '@',
       original: '@[David](1:@)',
     },
-    position: {start: 0, end: 6},
+    position: {start: 0, end: 5},
   };
 
   let {parts} = parseValue(mentionValue, [mentionPartType]);
@@ -110,7 +110,7 @@ test('generates correct parts', () => {
 
   expect(parts).toEqual<Part[]>([
     expectedMentionPart,
-    {text: ' hey!', position: {start: 6, end: 11}},
+    {text: ' hey!', position: {start: 5, end: 10}},
   ]);
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,6 +551,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/lodash@^4.14.172":
+  version "4.14.172"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
+  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
+
 "@types/node@*":
   version "14.14.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.16.tgz#3cc351f8d48101deadfed4c9e4f116048d437b4b"
@@ -2520,6 +2525,11 @@ lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
I just notice that previously we updated this library code using [patch](https://github.com/venn-city/mobile-app-v2/blob/master/patches/react-native-controlled-mentions%2B2.2.5.patch)

Since we now have this fork I decided to extract that code here.